### PR TITLE
iOS pass through custom user profile variable to smartwhere

### DIFF
--- a/sdk-ios/Tune/Tune/Tune.m
+++ b/sdk-ios/Tune/Tune/Tune.m
@@ -436,10 +436,18 @@ static TuneTracker *_sharedManager = nil;
 
 + (void)registerCustomProfileString:(NSString *)variableName withDefault:(NSString *)value {
     [[TuneManager currentManager].userProfile registerString:variableName withDefault:value];
+    if ([TuneSmartWhereHelper isSmartWhereAvailable]){
+        TuneSmartWhereHelper *tuneSmartWhereHelper = [TuneSmartWhereHelper getInstance];
+        [tuneSmartWhereHelper setAttributeValue:value forKey:variableName];
+    }
 }
 
 + (void)registerCustomProfileString:(NSString *)variableName withDefault:(NSString *)value hashed:(BOOL)shouldHash {
     [[TuneManager currentManager].userProfile registerString:variableName withDefault:value hashed:shouldHash];
+    if ([TuneSmartWhereHelper isSmartWhereAvailable]){
+        TuneSmartWhereHelper *tuneSmartWhereHelper = [TuneSmartWhereHelper getInstance];
+        [tuneSmartWhereHelper setAttributeValue:value forKey:variableName];
+    }
 }
 
 + (void)registerCustomProfileBoolean:(NSString *)variableName withDefault:(NSNumber *)value {
@@ -452,6 +460,10 @@ static TuneTracker *_sharedManager = nil;
 
 + (void)registerCustomProfileNumber:(NSString *)variableName withDefault:(NSNumber *)value {
     [[TuneManager currentManager].userProfile registerNumber:variableName withDefault:value];
+    if ([TuneSmartWhereHelper isSmartWhereAvailable]){
+        TuneSmartWhereHelper *tuneSmartWhereHelper = [TuneSmartWhereHelper getInstance];
+        [tuneSmartWhereHelper setAttributeValue:[value stringValue] forKey:variableName];
+    }
 }
 
 + (void)registerCustomProfileGeolocation:(NSString *)variableName withDefault:(TuneLocation *)value {
@@ -464,6 +476,10 @@ static TuneTracker *_sharedManager = nil;
 
 + (void)setCustomProfileStringValue:(NSString *)value forVariable:(NSString *)name {
     [[TuneManager currentManager].userProfile setStringValue:value forVariable:name];
+    if ([TuneSmartWhereHelper isSmartWhereAvailable]){
+        TuneSmartWhereHelper *tuneSmartWhereHelper = [TuneSmartWhereHelper getInstance];
+        [tuneSmartWhereHelper setAttributeValue:value forKey:name];
+    }
 }
 
 + (void)setCustomProfileBooleanValue:(NSNumber *)value forVariable:(NSString *)name {
@@ -476,6 +492,10 @@ static TuneTracker *_sharedManager = nil;
 
 + (void)setCustomProfileNumberValue:(NSNumber *)value forVariable:(NSString *)name {
     [[TuneManager currentManager].userProfile setNumberValue:value forVariable:name];
+    if ([TuneSmartWhereHelper isSmartWhereAvailable]){
+        TuneSmartWhereHelper *tuneSmartWhereHelper = [TuneSmartWhereHelper getInstance];
+        [tuneSmartWhereHelper setAttributeValue:[value stringValue] forKey:name];
+    }
 }
 
 + (void)setCustomProfileGeolocationValue:(TuneLocation *)value forVariable:(NSString *)name {
@@ -504,10 +524,18 @@ static TuneTracker *_sharedManager = nil;
 
 + (void)clearCustomProfileVariable:(NSString *)name {
     [[TuneManager currentManager].userProfile clearCustomVariables:[NSSet setWithObject:name]];
+    if ([TuneSmartWhereHelper isSmartWhereAvailable]){
+        TuneSmartWhereHelper *tuneSmartWhereHelper = [TuneSmartWhereHelper getInstance];
+        [tuneSmartWhereHelper clearAttributeValue:name];
+    }
 }
 
 + (void)clearAllCustomProfileVariables {
     [[TuneManager currentManager].userProfile clearCustomProfile];
+    if ([TuneSmartWhereHelper isSmartWhereAvailable]){
+        TuneSmartWhereHelper *tuneSmartWhereHelper = [TuneSmartWhereHelper getInstance];
+        [tuneSmartWhereHelper clearAllAttributeValues];
+    }
 }
 
 #pragma mark - Getter Methods

--- a/sdk-ios/Tune/Tune/TuneSmartWhereHelper.h
+++ b/sdk-ios/Tune/Tune/TuneSmartWhereHelper.h
@@ -8,6 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import "TuneSkyhookPayload.h"
+#import "TuneAnalyticsVariable.h"
 
 @protocol SmartWhereDelegate
 @end
@@ -70,6 +71,43 @@
  */
 - (void)processMappedEvent:(TuneSkyhookPayload*) payload;
 
+/*!
+ * Set custom user attributes for use in notification replacements and event conditions.
+ * @param value String value of the attribute value
+ * @param key Strting value of the attribute name
+ */
+- (void) setAttributeValue:(NSString*) value forKey: (NSString*) key;
+
+/*!
+ * Set custom user attributes for use in notification replacements and event conditions.
+ * @param tuneAnalyticsVariable TuneAnalyticsVariable
+ */
+- (void)setAttributeValueFromAnalyticsVariable:(TuneAnalyticsVariable *)tuneAnalyticsVariable;
+
+/*!
+ * Set custom user attributes for use in notification replacements and event conditions.
+ * @param payload TuneSkyhookPayload containing a TuneEvent with tags
+ */
+- (void)setAttributeValuesFromPayload:(TuneSkyhookPayload*) payload;
+
+/*!
+ * Clear a custom user attribute.
+ * @param variableName String value of the attribute name
+ */
+- (void)clearAttributeValue:(NSString*) variableName;
+
+/*!
+ * Clear all custom user attributes.
+ */
+- (void)clearAllAttributeValues;
+
+/*!
+ * Set custom user tracking attributes that will be sent as metadata in tracking calls.
+ * @param value String value of the attribute value
+ * @param key Strting value of the attribute name
+ */
+- (void) setTrackingAttributeValue:(NSString*) value forKey: (NSString*) key;
+
 @end
 
 #ifndef TUNE_SW_EventActionType_Defined
@@ -100,6 +138,7 @@ typedef enum TUNE_SW_EventActionType : NSInteger {
 typedef enum TUNE_SW_ProximityTriggerType : NSInteger {
     TUNE_SW_swNfcTap = 0,
     TUNE_SW_swQRScan = 1,
+    TUNE_SW_swNfcTapCancel = 2,
     TUNE_SW_swBleEnter = 10,
     TUNE_SW_swBleHover = 11,
     TUNE_SW_swBleDwell = 12,

--- a/sdk-ios/Tune/Tune/TuneSmartWhereHelper.m
+++ b/sdk-ios/Tune/Tune/TuneSmartWhereHelper.m
@@ -28,6 +28,7 @@ NSString * const TUNE_SMARTWHERE_DEBUG_LOGGING = @"DEBUG_LOGGING";
 NSString * const TUNE_SMARTWHERE_PACKAGE_NAME = @"PACKAGE_NAME";
 
 NSString * const TUNE_VERSION_STRING = @"TUNE_SDK_VERSION";
+NSString * const TUNE_MAT_ID_STRING = @"TUNE_MAT_ID";
 
 @interface TuneSmartWhereHelper()
 
@@ -81,6 +82,7 @@ NSString * const TUNE_VERSION_STRING = @"TUNE_SDK_VERSION";
     }
     
     [self setTrackingAttributeValue:TUNEVERSION forKey:TUNE_VERSION_STRING];
+    [self setTrackingAttributeValue:[Tune tuneId] forKey:TUNE_MAT_ID_STRING];
     
     WarnLog(@"TUNE: Starting SmartWhere Proximity Monitoring");
     

--- a/sdk-ios/Tune/Tune/TuneSmartWhereTriggeredEventManager.m
+++ b/sdk-ios/Tune/Tune/TuneSmartWhereTriggeredEventManager.m
@@ -32,6 +32,7 @@
 - (void)handleTriggeredEvent:(TuneSkyhookPayload*)payload {
     if ([TuneSmartWhereHelper isSmartWhereAvailable]){
         TuneSmartWhereHelper *tuneSmartWhereHelper = [TuneSmartWhereHelper getInstance];
+        [tuneSmartWhereHelper setAttributeValuesFromPayload:payload];
         [tuneSmartWhereHelper processMappedEvent:payload];
     }
 }

--- a/sdk-ios/Tune/TuneMarketingConsoleSDKTests/TuneSmartWhereTriggeredEventManagerTests.m
+++ b/sdk-ios/Tune/TuneMarketingConsoleSDKTests/TuneSmartWhereTriggeredEventManagerTests.m
@@ -98,9 +98,10 @@
 
 #pragma mark - handleTriggeredEvent tests
 
-- (void)testhandleTriggeredEventCallsProcessMappedEvent {
+- (void)testhandleTriggeredEventCallsSetAttributeValuesFromPayloadAndProcessMappedEvent {
     [[[[mockTuneSmartWhereHelper stub] classMethod] andReturnValue:OCMOCK_VALUE(YES)] isSmartWhereAvailable];
     
+    [[mockTuneSmartWhereHelper expect] setAttributeValuesFromPayload:mockPayload];
     [[mockTuneSmartWhereHelper expect] processMappedEvent:mockPayload];
     
     [testObj handleTriggeredEvent: mockPayload];
@@ -111,6 +112,7 @@
 - (void)testhandleTriggeredEventDoesntCallProcessMappedEventWhenNotAvailable {
     [[[[mockTuneSmartWhereHelper stub] classMethod] andReturnValue:OCMOCK_VALUE(NO)] isSmartWhereAvailable];
     
+    [[mockTuneSmartWhereHelper reject] setAttributeValuesFromPayload:mockPayload];
     [[mockTuneSmartWhereHelper reject] processMappedEvent:OCMOCK_ANY];
     
     [testObj handleTriggeredEvent: mockPayload];


### PR DESCRIPTION
I have some changes that we'd like to propose for the Tune SDK.
The main thing that it does is pass attributes through to smartwhere, with permission of course, via either added tags to a measured event or registered custom user profile variable. The values don't get sent to our servers but can be used for notification substitutions and conditions for determining whether an event should be fired.

In addition, it adds two tracking variables. The TUNE Version string and the TUNE Mat Id. These values will be passed to our servers with tracking and then passed along to TUNE for the IAM visit sending.

Thanks,
Gordon